### PR TITLE
Additional contexts for which the "Add to Favorites *" context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.6 | 2022/09/15
+
+- enabled the "Add to Favorites" and "Add to Favorites Group" context menu items in additional context menus such as when right clicking an open file tab, or in the text of an open editor. 
+
+
 ## 2.4.5 | 2018/11/29
 
 - fixed vulnerability issue

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Open Visual Studio Code press CTRL+p and type or copy and paste:
 `favorites.useTrash`: boolean (default `false`)
 - if set to `true`, extension will try to use system trash when resource (file or directory is deleted)
 
+`favorites.includeInDocumentBodyContextMenu` : boolean (default `false`)
+- if set to `true`, the two "Add to * favorites" commands will be included in the editor context menu that appears when right-clicking the body of an open document.
+
+`favorites.includeInEditorTabContextMenu` : boolean (default `true`)
+- if set to `true`, the two "Add to * favorites" commands will be included in the context menu for the tab of a specific file (e.g. the menu that appears when right-clicking the tab of an open document).
+
 ## Keyboard browsing
 
 You can browse favorites using **keyboard only** by executing command `Favorites: Browse` command from palette. Assign keyboard shortcut if needed.
@@ -89,9 +95,9 @@ You can browse favorites using **keyboard only** by executing command `Favorites
 ## Usage
 
 #### Adding to favorites
-Right-click item in File explorer and select `Add to favorites`.
+Right-click item in File explorer, an open file tab, or the background of an open editor and select `Add to favorites`.
 #### Adding to favorites group or subgroup
-Right-click item in File explorer and select `Add to favorites group`, then select group from list.
+Right-click item in File explorer, an open file tab, or the background of an open editor and select `Add to favorites group`, then select group from list.
 #### Removing from favorites
 Right-click item in Favorites view and select `Remove from favorites`
 #### Create favorites group

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "favorites",
     "displayName": "Favorites",
     "description": "Add files and directories to workspace favorites. Create groups of directories and files. Time saver for complex projects.",
-    "version": "2.4.5",
+    "version": "2.4.6",
     "categories": [
         "Other"
     ],
@@ -131,6 +131,38 @@
                 },
                 {
                     "command": "favorites.addToFavoritesGroup",
+                    "group": "favorites"
+                }
+            ],
+            "editor/title": [
+                {
+                    "command": "favorites.addToFavorites",
+                    "group": "favorites"
+                },
+                {
+                    "command": "favorites.addToFavoritesGroup",
+                    "group": "favorites"
+                }
+            ],
+            "editor/title/context": [
+                {
+                    "command": "favorites.addToFavorites",
+                    "group": "favorites"
+                },
+                {
+                    "command": "favorites.addToFavoritesGroup",
+                    "group": "favorites"
+                }
+            ],
+            "editor/context": [
+                {
+                    "when": "resourceScheme == file",
+                    "command": "favorites.addFileToFavorites",
+                    "group": "favorites"
+                },
+                {
+                    "when": "resourceScheme == file",
+                    "command": "favorites.addFileToFavoritesGroup",
                     "group": "favorites"
                 }
             ],
@@ -487,6 +519,14 @@
             {
                 "command": "favorites.addToFavoritesGroup",
                 "title": "Favorites: Add to group of favorites"
+            },
+            {
+                "command": "favorites.addFileToFavorites",
+                "title": "Favorites: Add file to favorites"
+            },
+            {
+                "command": "favorites.addFileToFavoritesGroup",
+                "title": "Favorites: Add file to group of favorites"
             },
             {
                 "command": "favorites.deleteFavorite",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,16 @@
                     ],
                     "default": "ASC",
                     "description": "Specify an order for all favorites"
+                },
+                "favorites.includeInDocumentBodyContextMenu": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Display the 'Favorites: Add to * favorites' commands in the editor context menu"
+                },
+                "favorites.includeInEditorTabContextMenu": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Display the 'Favorites: Add to * favorites' commands in the context menu for the tab of a specific file"
                 }
             }
         },
@@ -146,22 +156,24 @@
             ],
             "editor/title/context": [
                 {
+                    "when": "config.favorites.includeInEditorTabContextMenu",
                     "command": "favorites.addToFavorites",
                     "group": "favorites"
                 },
                 {
+                    "when": "config.favorites.includeInEditorTabContextMenu",
                     "command": "favorites.addToFavoritesGroup",
                     "group": "favorites"
                 }
             ],
             "editor/context": [
                 {
-                    "when": "resourceScheme == file",
+                    "when": "config.favorites.includeInDocumentBodyContextMenu && resourceScheme == file",
                     "command": "favorites.addFileToFavorites",
                     "group": "favorites"
                 },
                 {
-                    "when": "resourceScheme == file",
+                    "when": "config.favorites.includeInDocumentBodyContextMenu && resourceScheme == file",
                     "command": "favorites.addFileToFavoritesGroup",
                     "group": "favorites"
                 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,8 @@ export interface WorkspaceConfiguration {
     storageRegistry: string[];
     groupsFirst: boolean;
     sortDirection: "ASC" | "DESC";
+    includeInDocumentBodyContextMenu: boolean;
+    includeInEditorTabContextMenu: boolean;
 }
 
 export interface StoredResource {


### PR DESCRIPTION
Additional contexts for which the "Add to Favorites" and "Add to Favorites Group" context menu items appear

enabled the "Add to Favorites" and "Add to Favorites Group" context menu items in additional context menus such as when right clicking an open file tab, or in the text of an open editor.

![VGvPoz4zWz](https://user-images.githubusercontent.com/962210/190317498-0c3b1bae-db25-466a-ad9a-bc1346bd87af.png)
![VGvPoz4zWz](https://user-images.githubusercontent.com/962210/190317585-606fee50-fc5a-49d1-bf2a-6a9c2252b952.png)
![6BgPimnd7Q](https://user-images.githubusercontent.com/962210/190317725-a534fa7a-5e71-44af-a553-0f9d8e161abd.png)

#45 
